### PR TITLE
Redesign hook: solid back wall with short J-clip notch

### DIFF
--- a/src/components/HookDesigner.tsx
+++ b/src/components/HookDesigner.tsx
@@ -16,7 +16,6 @@ function HookMesh({ params, center }: { params: HookParams; center: THREE.Vector
   }, [geometry])
 
   // Offset the mesh so its bounding-box centre sits at world origin.
-  // This keeps OrbitControls orbiting the hook instead of the wire slot.
   // Geometry coordinates are untouched so export values stay correct.
   return (
     <mesh
@@ -32,6 +31,8 @@ function HookMesh({ params, center }: { params: HookParams; center: THREE.Vector
 
 // ─── Wire Preview ─────────────────────────────────────────────────────────────
 
+const GRID_SPACING = 54 // outer wire-centre to wire-centre distance (mm)
+
 function WirePreview({
   wireDiameter,
   width,
@@ -44,25 +45,24 @@ function WirePreview({
   show: boolean
 }) {
   if (!show) return null
-  // Visualise the grid wire as a cylinder along X (the extrusion/width axis).
-  // Position is offset to stay inside the slot even after the hook is centred.
   return (
-    <mesh
-      rotation={[0, 0, Math.PI / 2]}
-      position={[-offset.x, -offset.y, -offset.z]}
-    >
-      <cylinderGeometry args={[wireDiameter / 2, wireDiameter / 2, width * 2, 16]} />
-      <meshStandardMaterial color="#888" metalness={0.8} roughness={0.2} />
-    </mesh>
+    <>
+      {/* Top wire — gripped by the J-clip */}
+      <mesh rotation={[0, 0, Math.PI / 2]} position={[-offset.x, -offset.y, -offset.z]}>
+        <cylinderGeometry args={[wireDiameter / 2, wireDiameter / 2, width * 2, 16]} />
+        <meshStandardMaterial color="#888" metalness={0.8} roughness={0.2} />
+      </mesh>
+      {/* Lower wire — body bottom rests on this */}
+      <mesh rotation={[0, 0, Math.PI / 2]} position={[-offset.x, -offset.y - GRID_SPACING, -offset.z]}>
+        <cylinderGeometry args={[wireDiameter / 2, wireDiameter / 2, width * 2, 16]} />
+        <meshStandardMaterial color="#888" metalness={0.8} roughness={0.2} />
+      </mesh>
+    </>
   )
 }
 
 // ─── Scene ────────────────────────────────────────────────────────────────────
 
-// Forces OrbitControls to orient the camera toward its target on mount.
-// We use `get()` inside the effect — not `useThree()` at render time — because
-// OrbitControls.makeDefault writes the controls instance to the R3F store via
-// its own useEffect (earlier sibling). `get()` reads the live state at run-time.
 function ControlsInit() {
   const get = useThree((s) => s.get)
   React.useEffect(() => {
@@ -81,7 +81,6 @@ function ControlsInit() {
 }
 
 function Scene({ params, showWire }: { params: HookParams; showWire: boolean }) {
-  // Compute bounding box center once so both mesh and wire share the same offset
   const center = React.useMemo(() => {
     const geo = buildHookGeometry(params)
     geo.computeBoundingBox()
@@ -127,16 +126,19 @@ function Scene({ params, showWire }: { params: HookParams; showWire: boolean }) 
 // ─── Main Component ──────────────────────────────────────────────────────────
 
 export function HookDesigner() {
-  // Leva control panel — mirrors the parameter set from the standalone HTML
   const [
     {
       wireDiameter,
       tolerance,
       wallThickness,
       hookHeight,
+      bodyLength,
+      clipDepth,
       armLength,
       armThickness,
+      armMountHeight,
       width,
+      stopperEnabled,
       stopperHeight,
       stopperThickness,
       showWire,
@@ -146,19 +148,23 @@ export function HookDesigner() {
     "Grid wire": folder({
       wireDiameter: { value: DEFAULT_PARAMS.wireDiameter, min: 2, max: 8, step: 0.5, label: "Diameter (mm)" },
       tolerance: { value: DEFAULT_PARAMS.tolerance, min: 0, max: 2, step: 0.1, label: "Toleranse (mm)" },
+      clipDepth: { value: DEFAULT_PARAMS.clipDepth, min: 6, max: 30, step: 1, label: "Klype-dybde (mm)" },
     }),
     "Hook body": folder({
       wallThickness: { value: DEFAULT_PARAMS.wallThickness, min: 1.5, max: 8, step: 0.5, label: "Veggtykkelse (mm)" },
-      hookHeight: { value: DEFAULT_PARAMS.hookHeight, min: 15, max: 80, step: 1, label: "Høyde (mm)" },
+      hookHeight: { value: DEFAULT_PARAMS.hookHeight, min: 5, max: 30, step: 1, label: "Klyp-høyde (mm)" },
+      bodyLength: { value: DEFAULT_PARAMS.bodyLength, min: 20, max: 120, step: 1, label: "Kropp-lengde (mm)" },
       width: { value: DEFAULT_PARAMS.width, min: 10, max: 80, step: 1, label: "Bredde (mm)" },
     }),
     "Arm": folder({
       armLength: { value: DEFAULT_PARAMS.armLength, min: 10, max: 120, step: 1, label: "Lengde (mm)" },
       armThickness: { value: DEFAULT_PARAMS.armThickness, min: 3, max: 20, step: 0.5, label: "Tykkelse (mm)" },
+      armMountHeight: { value: DEFAULT_PARAMS.armMountHeight, min: 10, max: 80, step: 1, label: "Brakett-høyde (mm)" },
     }),
     "Stopper": folder({
-      stopperHeight: { value: DEFAULT_PARAMS.stopperHeight, min: 0, max: 20, step: 0.5, label: "Høyde (mm)" },
-      stopperThickness: { value: DEFAULT_PARAMS.stopperThickness, min: 0, max: 10, step: 0.5, label: "Tykkelse (mm)" },
+      stopperEnabled: { value: DEFAULT_PARAMS.stopperEnabled, label: "Stopper" },
+      stopperHeight: { value: DEFAULT_PARAMS.stopperHeight, min: 2, max: 20, step: 0.5, label: "Høyde (mm)" },
+      stopperThickness: { value: DEFAULT_PARAMS.stopperThickness, min: 1, max: 10, step: 0.5, label: "Tykkelse (mm)" },
     }),
     "Visning": folder({
       showWire: { value: true, label: "Vis tråd" },
@@ -171,9 +177,13 @@ export function HookDesigner() {
     tolerance,
     wallThickness,
     hookHeight,
+    bodyLength,
+    clipDepth,
     armLength,
     armThickness,
+    armMountHeight,
     width,
+    stopperEnabled,
     stopperHeight,
     stopperThickness,
   }

--- a/src/lib/hookGeometry.ts
+++ b/src/lib/hookGeometry.ts
@@ -4,75 +4,40 @@ export interface HookParams {
   wireDiameter: number
   tolerance: number
   wallThickness: number
-  hookHeight: number
-  armLength: number
-  armThickness: number
+  hookHeight: number       // clip cap above the wire
+  bodyLength: number       // how far the back wall hangs below the wire (to lower grid wire)
+  clipDepth: number        // how far below wire centre the J-clip notch extends (mm)
+  armLength: number        // horizontal reach of the shelf
+  armThickness: number     // constant vertical depth of the arm/shelf
+  armMountHeight: number   // shelf height above body bottom; controls bracket steepness
   width: number
-  stopperHeight: number
-  stopperThickness: number
+  stopperEnabled: boolean  // whether to add an upward bump at the arm tip
+  stopperHeight: number    // bump height above shelf top
+  stopperThickness: number // bump depth (Z extent past arm tip)
 }
 
 export const DEFAULT_PARAMS: HookParams = {
   wireDiameter: 4,
   tolerance: 0.5,
   wallThickness: 3,
-  hookHeight: 35,
-  armLength: 50,
+  hookHeight: 10,
+  bodyLength: 54,
+  clipDepth: 10,        // J-clip notch extends 10mm below wire centre
+  armLength: 55,
   armThickness: 8,
+  armMountHeight: 40,   // shelf is 40mm above body bottom (~3/4 of bodyLength)
   width: 30,
+  stopperEnabled: true,
   stopperHeight: 6,
   stopperThickness: 3,
 }
 
-/**
- * Builds the 2D cross-section profile of the J-hook in the ZY plane.
- * Returns an array of [z, y] points forming a closed polygon.
- *
- * Coordinate convention (matches the world scene):
- *   Z = depth from wall (positive = toward room)
- *   Y = height (positive = up)
- *
- * Wire centre sits at (z=0, y=0). The slot is open downward so the hook
- * can be lowered onto the grid wire from above.
- */
-export function buildHookProfile(p: HookParams): [number, number][] {
-  const wireRadius = p.wireDiameter / 2
-  const wg = wireRadius + p.tolerance // half-slot width (wire radius + clearance)
-
-  // Z coordinates
-  const zb = -(wg + p.wallThickness) // back wall outer face
-  const zbi = -wg // back wall inner face (slot edge)
-  const zfi = wg // front wall inner face (slot edge)
-  const zfo = wg + p.wallThickness // front wall outer face
-  const zsi = zfo + p.armLength // stopper inner face (arm tip)
-  const zat = zsi + p.stopperThickness // stopper outer face
-
-  // Y coordinates
-  const ysb = -(wg + p.wallThickness) // body/slot bottom
-  const yt = p.hookHeight // hook top
-  const ybb = wg // arm top (flush with slot top)
-  const yab = -(p.armThickness) // arm bottom
-  const yst = ybb + p.stopperHeight // stopper top
-
-  return [
-    [zb, ysb], // back outer, bottom
-    [zb, yt], // back outer, top
-    [zfo, yt], // top cap, front outer
-    [zfo, ybb], // front wall, arm junction top
-    [zsi, ybb], // arm top, inner stopper face
-    [zsi, yst], // stopper, inner top
-    [zat, yst], // stopper, outer top
-    [zat, yab], // arm tip, bottom
-    [zfo, yab], // arm bottom, front outer
-    [zfi, yab], // front wall inner, arm bottom
-    [zfi, wg], // front wall inner, slot top  (index 10 — skipped in buildHookGeometry)
-    [zbi, wg], // back wall inner, slot top   (index 11 — skipped; arc inserted instead)
-    [zbi, ysb], // back wall inner, bottom → closes polygon
-  ]
-}
-
-/** Approximate an arc from `startAngle` to `endAngle` (radians) as lineTo points. */
-function arcPoints(cx: number, cy: number, r: number, startAngle: number, endAngle: number, segments = 24): [number, number][] {
+/** Approximate an arc from startAngle to endAngle (radians) as lineTo points. */
+function arcPoints(
+  cx: number, cy: number, r: number,
+  startAngle: number, endAngle: number,
+  segments = 24,
+): [number, number][] {
   const pts: [number, number][] = []
   for (let i = 0; i <= segments; i++) {
     const t = startAngle + (endAngle - startAngle) * (i / segments)
@@ -82,56 +47,175 @@ function arcPoints(cx: number, cy: number, r: number, startAngle: number, endAng
 }
 
 /**
- * Creates a BufferGeometry for the hook by extruding the ZY profile in the X direction.
+ * Creates a BufferGeometry for the hook by extruding a 2D profile.
  *
- * THREE.ExtrudeGeometry extrudes a shape (defined in XY) along +Z.
- * We define the shape with profile-Z→shape-X and profile-Y→shape-Y,
- * then rotate the resulting geometry -90° around Y so that:
- *   shape X (= hook depth)  → world Z
- *   shape Y (= hook height) → world Y
- *   extrusion Z (= width)   → world X (centred at 0)
+ * Shape overview (side view, ZY plane, wire centre at origin):
+ *
+ *   J-clip — small bracket at the TOP only; grips the upper grid wire (Y=0)
+ *   Back wall — solid plate running the full body height (no inner walls below clip)
+ *   Shelf arm — horizontal surface extending forward from the clip-zone front face
+ *   Triangle bracket — diagonal from arm tip all the way back to body bottom
+ *   Stopper — optional upward bump at the arm tip
+ *
+ * Retention: J-clip prevents upward lift-off. The diagonal bracket's bottom corner
+ * rests against the lower grid wire; gravity + arm load keeps the hook seated.
+ *
+ * The outer Shape is a solid silhouette (no inner wall edges). The wire slot is
+ * cut as a closed THREE.Path hole via shape.holes — this avoids the full-height
+ * hollow channel of the previous design.
+ *
+ * THREE.ExtrudeGeometry extrudes a Shape (in its XY plane) along +Z.
+ * We define shape-X = profile-Z (depth) and shape-Y = profile-Y (height),
+ * then rotate the geometry -90° around Y so extrusion → world-X (width).
  */
 export function buildHookGeometry(params: HookParams): THREE.BufferGeometry {
-  const profile = buildHookProfile(params)
-  const wg = params.wireDiameter / 2 + params.tolerance
+  // Guard: fall back to defaults for any undefined field (HMR / stale Leva state)
+  const d = DEFAULT_PARAMS
+  const p: HookParams = {
+    wireDiameter:    params.wireDiameter    ?? d.wireDiameter,
+    tolerance:       params.tolerance       ?? d.tolerance,
+    wallThickness:   params.wallThickness   ?? d.wallThickness,
+    hookHeight:      params.hookHeight      ?? d.hookHeight,
+    bodyLength:      params.bodyLength      ?? d.bodyLength,
+    clipDepth:       params.clipDepth       ?? d.clipDepth,
+    armLength:       params.armLength       ?? d.armLength,
+    armThickness:    params.armThickness    ?? d.armThickness,
+    armMountHeight:  params.armMountHeight  ?? d.armMountHeight,
+    width:           params.width           ?? d.width,
+    stopperEnabled:  params.stopperEnabled  ?? d.stopperEnabled,
+    stopperHeight:   params.stopperHeight   ?? d.stopperHeight,
+    stopperThickness: params.stopperThickness ?? d.stopperThickness,
+  }
 
-  // Profile slot section (indices 9-12):
-  //   9:  [zfi, yab] (wg, -arm)  — inner front wall bottom  (drawn)
-  //  10:  [zfi, wg]  (wg, wg)    — inner front wall top     SKIPPED
-  //  11:  [zbi, wg]  (-wg, wg)   — inner back wall top      SKIPPED
-  //  12:  [zbi, ysb] (-wg, ysb)  — inner back wall bottom   (drawn last)
+  const wg   = p.wireDiameter / 2 + p.tolerance   // half-slot width
+  const zb   = -(wg + p.wallThickness)             // outer back face
+  const zbi  = -wg                                 // inner back face
+  const zfi  = wg                                  // inner front face
+  const zfo  = wg + p.wallThickness                // outer front face
+  const zarm = zfo + p.armLength                   // arm tip Z
+
+  const yt   = p.hookHeight                        // clip cap top
+  const ysb  = -p.bodyLength                       // body bottom (lower wire level)
+
+  // Clamp armMountHeight so shelf is always above the arm thickness
+  const mountH = Math.max(p.armMountHeight, p.armThickness + 1)
+  const yShelf = ysb + mountH                      // shelf Y level
+
+  // Arc for the wire slot ceiling: CCW semicircle (wg,0)→(0,wg)→(-wg,0)
+  const arc = arcPoints(0, 0, wg, 0, Math.PI, 24)
+
+  // ── Shape overview ────────────────────────────────────────────────────────────
   //
-  // Replace the flat slot ceiling ([zfi,wg]→[zbi,wg]) with a semicircular arc:
-  //   centre (0,0), radius wg, sweeping CCW from angle 0 to π.
-  //   Path: (wg,0) → apex (0,wg) → (-wg,0)
-  // The inner walls shorten from ±wg to 0 (the arc end-points), giving a D-shaped slot
-  // that matches the wire profile instead of a rectangular one.
-  const arcPts = arcPoints(0, 0, wg, 0, Math.PI, 24) // (wg,0) → (0,wg) → (-wg,0)
+  // The hook has two distinct structural zones that share only the outer back wall:
+  //
+  //   CLIP ZONE  (yShelf → yt, full width zb→zfo):
+  //     The J-clip bracket. Solid block with the slot hole punched through it.
+  //     The lower grid wire passes ALONGSIDE the outer back face (zb) here —
+  //     it does NOT enter the solid. The J-clip hole keeps the wire slot clear.
+  //
+  //   BRACKET ZONE  (ysb → yShelf, front half only zbi→zfo+armLength):
+  //     The arm shelf + diagonal brace. Lives entirely at Z ≥ zbi (-2.5 mm),
+  //     which keeps it clear of the lower grid wire at Z=0 down at Y=ysb.
+  //     The outer back wall does NOT extend into this zone — there is no
+  //     back-wall material at negative Z below the arm mount level.
+  //
+  // Because the back wall (negative Z) stops at yShelf, and the bracket zone
+  // is entirely at positive-ish Z, the lower wire at (Z=0, Y=ysb) sits just
+  // outside the solid on its back-left face rather than going through it.
+  //
+  // Profile trace (CCW):
+  //   back-wall bottom (zb, yShelf) → up back wall → top cap → down outer front
+  //   → shelf → arm tip → diagonal to (zbi, ysb) → body bottom → closePath
 
   const shape = new THREE.Shape()
-  shape.moveTo(profile[0][0], profile[0][1])
-  for (let i = 1; i <= 9; i++) {
-    shape.lineTo(profile[i][0], profile[i][1])
-  }
-  for (const [x, y] of arcPts) {
-    shape.lineTo(x, y)
-  }
-  shape.lineTo(profile[12][0], profile[12][1])
-  shape.closePath()
 
-  const extrudeSettings: THREE.ExtrudeGeometryOptions = {
-    depth: params.width,
+  // ── Clip zone: back wall + top cap + outer front ──────────────────────────────
+  shape.moveTo(zb,  yShelf)       // back-wall bottom corner (arm mount level)
+  shape.lineTo(zb,  yt)           // up full outer back wall
+  shape.lineTo(zfo, yt)           // top cap
+  shape.lineTo(zfo, yShelf)       // outer front face down to shelf level
+
+  // ── Bracket zone: shelf + arm tip + diagonal brace ───────────────────────────
+  shape.lineTo(zarm, yShelf)      // shelf top (horizontal)
+
+  if (p.stopperEnabled) {
+    shape.lineTo(zarm,                      yShelf + p.stopperHeight)
+    shape.lineTo(zarm + p.stopperThickness, yShelf + p.stopperHeight)
+    shape.lineTo(zarm + p.stopperThickness, yShelf - p.armThickness)
+  } else {
+    shape.lineTo(zarm, yShelf - p.armThickness)
+  }
+
+  // Diagonal brace: arm tip → inner back face at body bottom.
+  // Ends at zbi (= -wg = -2.5 mm), not zb, so the outer-back zone at
+  // negative Z stays clear of the lower wire at Z=0.
+  shape.lineTo(zbi, ysb)
+
+  // Body bottom: 3 mm step from inner back (zbi) to outer back (zb) — the thin
+  // strip of material at the very base of the back wall.
+  shape.lineTo(zb, ysb)
+
+  // Left face: back wall going up from body bottom to back-wall bottom corner.
+  // closePath() draws this segment automatically.
+  shape.closePath()               // (zb, ysb) → (zb, yShelf) — completes back wall
+
+  // ── J-clip slot hole ─────────────────────────────────────────────────────────
+  // Closed void punched into the clip zone. Floor is clamped to stay above yShelf
+  // so the hole never reaches into the open bracket zone below.
+  const ySlotBot = Math.max(-p.clipDepth, yShelf + 1)
+
+  const slotPath = new THREE.Path()
+  slotPath.moveTo(zfi, ySlotBot)
+  slotPath.lineTo(zfi, 0)
+  for (const [x, y] of arc) slotPath.lineTo(x, y)
+  slotPath.lineTo(zbi, ySlotBot)
+  slotPath.closePath()
+
+  shape.holes = [slotPath]
+
+  const geometry = new THREE.ExtrudeGeometry(shape, {
+    depth: p.width,
     bevelEnabled: false,
-  }
+  })
 
-  const geometry = new THREE.ExtrudeGeometry(shape, extrudeSettings)
+  // Centre in X (extrusion runs 0→width along shape's Z axis)
+  geometry.translate(0, 0, -p.width / 2)
 
-  // Centre the extrusion in X (extrusion runs 0→width along shape's Z axis)
-  geometry.translate(0, 0, -params.width / 2)
-
-  // Rotate so the extrusion (originally shape's +Z) aligns with world X:
-  //   rotation.y = -π/2 maps shape-Z→world-X, shape-X→world-Z
+  // Rotate so extrusion aligns with world X: -π/2 around Y
   geometry.applyMatrix4(new THREE.Matrix4().makeRotationY(-Math.PI / 2))
 
   return geometry
+}
+
+/**
+ * Returns representative 2D profile vertices for preview/display.
+ * Returns the outer silhouette only — matches the outer Shape in buildHookGeometry.
+ * The J-clip slot (hole) is omitted; the profile shows the solid boundary.
+ */
+export function buildHookProfile(p: HookParams): [number, number][] {
+  const wg   = p.wireDiameter / 2 + p.tolerance
+  const zb   = -(wg + p.wallThickness)
+  const zbi  = -wg
+  const zfo  = wg + p.wallThickness
+  const zarm = zfo + p.armLength
+  const yt   = p.hookHeight
+  const ysb  = -p.bodyLength
+  const mountH = Math.max(p.armMountHeight, p.armThickness + 1)
+  const yShelf = ysb + mountH
+
+  return [
+    [zb,   yShelf],  // back-wall bottom corner (arm mount level)
+    [zb,   yt],
+    [zfo,  yt],
+    [zfo,  yShelf],
+    [zarm, yShelf],
+    ...(p.stopperEnabled ? [
+      [zarm,                      yShelf + p.stopperHeight],
+      [zarm + p.stopperThickness, yShelf + p.stopperHeight],
+      [zarm + p.stopperThickness, yShelf - p.armThickness],
+    ] as [number, number][] : [[zarm, yShelf - p.armThickness]] as [number, number][]),
+    [zbi,  ysb],  // diagonal to inner back at body bottom
+    [zb,   ysb],  // body bottom (outer back)
+    // closePath → (zb, yShelf) — closes the back wall
+  ]
 }


### PR DESCRIPTION
## Summary

- Replaces the full-height open slot channel with a closed `shape.holes` cutout — the back wall is now a solid continuous plate rather than two parallel walls with a gap running the full body height
- J-clip slot is a short closed notch (default 10mm) instead of a 54mm channel, so the lower grid wire sits *against* the back wall rather than through the body
- Diagonal bracket connects arm tip to the inner-back face at body bottom, keeping the solid clear of the lower wire at Z=0
- Adds `clipDepth` parameter (Klype-dybde slider, 6–30mm) to tune how deep the J-clip notch extends

## Test plan

- [ ] Hook renders without NaN errors after page reload
- [ ] Lower wire preview sits against the back wall (not through the body)
- [ ] Upper wire sits inside the J-clip keyhole slot
- [ ] Dragging `clipDepth` slider grows/shrinks the notch correctly
- [ ] Toggling stopper and changing arm params shows no regressions
- [ ] `.stl` and `.3mf` exports open correctly in Bambu Studio

🤖 Generated with [Claude Code](https://claude.com/claude-code)