### PR TITLE
Rebuild hook geometry from scratch to match Shapr3D reference

### DIFF
--- a/src/components/HookDesigner.tsx
+++ b/src/components/HookDesigner.tsx
@@ -51,13 +51,10 @@ function GridPreview({
     const xLeft = -width / 2
     const xRight =  width / 2
 
-    // rowMax = 0: J-clip always grips the wire at grid row 0 (Y=0).
-    // ceil (not floor) ensures we only show wires that fall within the hook's body length —
-    // e.g. bodyLength=120 with gridOuter=54 → rows -2,-1,0 (wires at 0,-54,-108), not -3.
+    // rowMax = 0: the gripped wire always sits at grid row 0 (Y=0).
     const rowMin = Math.ceil(yBot / gridOuter)
     const rowMax = 0
     // Columns offset by half a spacing so the hook sits between vertical wires, not on one.
-    // Column k is at X = (k + 0.5) * gridOuter; find the k range that brackets the hook width.
     const colMin = Math.floor(xLeft / gridOuter - 0.5)
     const colMax = Math.ceil(xRight / gridOuter - 0.5)
 
@@ -174,14 +171,14 @@ export function HookDesigner() {
     {
       wireDiameter,
       tolerance,
-      wallThickness,
-      hookHeight,
-      bodyLength,
-      clipDepth,
-      armLength,
-      armThickness,
-      armMountHeight,
       width,
+      wallThickness,
+      clipWallThickness,
+      clipCapHeight,
+      clipOpeningDepth,
+      bodyLength,
+      armLength,
+      armTopOffset,
       stopperEnabled,
       stopperHeight,
       stopperThickness,
@@ -190,27 +187,29 @@ export function HookDesigner() {
     },
     set,
   ] = useControls(() => ({
-    "Grid wire": folder({
+    "Gitterwire": folder({
       wireDiameter: { value: DEFAULT_PARAMS.wireDiameter, min: 2, max: 8, step: 0.5, label: "Diameter (mm)" },
       tolerance: { value: DEFAULT_PARAMS.tolerance, min: 0, max: 2, step: 0.1, label: "Toleranse (mm)" },
-      clipDepth: { value: DEFAULT_PARAMS.clipDepth, min: 6, max: 30, step: 1, label: "Klype-dybde (mm)" },
       gridOuter: { value: 54, min: 40, max: 80, step: 0.5, label: "Rutestørrelse (mm)" },
     }),
-    "Hook body": folder({
-      wallThickness: { value: DEFAULT_PARAMS.wallThickness, min: 1.5, max: 8, step: 0.5, label: "Veggtykkelse (mm)" },
-      hookHeight: { value: DEFAULT_PARAMS.hookHeight, min: 5, max: 30, step: 1, label: "Klyp-høyde (mm)" },
-      bodyLength: { value: DEFAULT_PARAMS.bodyLength, min: 20, max: 120, step: 1, label: "Kropp-lengde (mm)" },
+    "J-klype": folder({
+      clipWallThickness: { value: DEFAULT_PARAMS.clipWallThickness, min: 2, max: 12, step: 0.5, label: "Yttervegg (mm)" },
+      clipCapHeight: { value: DEFAULT_PARAMS.clipCapHeight, min: 4, max: 20, step: 0.5, label: "Topphøyde (mm)" },
+      clipOpeningDepth: { value: DEFAULT_PARAMS.clipOpeningDepth, min: 5, max: 25, step: 0.5, label: "Åpning nedover (mm)" },
+    }),
+    "Kropp": folder({
+      wallThickness: { value: DEFAULT_PARAMS.wallThickness, min: 2, max: 12, step: 0.5, label: "Bakvegg (mm)" },
+      bodyLength: { value: DEFAULT_PARAMS.bodyLength, min: 40, max: 150, step: 1, label: "Høyde (mm)" },
       width: { value: DEFAULT_PARAMS.width, min: 10, max: 80, step: 1, label: "Bredde (mm)" },
     }),
     "Arm": folder({
-      armLength: { value: DEFAULT_PARAMS.armLength, min: 10, max: 120, step: 1, label: "Lengde (mm)" },
-      armThickness: { value: DEFAULT_PARAMS.armThickness, min: 3, max: 20, step: 0.5, label: "Tykkelse (mm)" },
-      armMountHeight: { value: DEFAULT_PARAMS.armMountHeight, min: 10, max: 80, step: 1, label: "Brakett-høyde (mm)" },
+      armLength: { value: DEFAULT_PARAMS.armLength, min: 30, max: 200, step: 1, label: "Lengde (mm)" },
+      armTopOffset: { value: DEFAULT_PARAMS.armTopOffset, min: 15, max: 80, step: 1, label: "Arm-høyde (mm)" },
     }),
     "Stopper": folder({
-      stopperEnabled: { value: DEFAULT_PARAMS.stopperEnabled, label: "Stopper" },
-      stopperHeight: { value: DEFAULT_PARAMS.stopperHeight, min: 2, max: 20, step: 0.5, label: "Høyde (mm)" },
-      stopperThickness: { value: DEFAULT_PARAMS.stopperThickness, min: 1, max: 10, step: 0.5, label: "Tykkelse (mm)" },
+      stopperEnabled: { value: DEFAULT_PARAMS.stopperEnabled, label: "På" },
+      stopperHeight: { value: DEFAULT_PARAMS.stopperHeight, min: 2, max: 25, step: 0.5, label: "Høyde (mm)" },
+      stopperThickness: { value: DEFAULT_PARAMS.stopperThickness, min: 2, max: 15, step: 0.5, label: "Tykkelse (mm)" },
     }),
     "Visning": folder({
       showGrid: { value: true, label: "Vis rutenett" },
@@ -221,14 +220,14 @@ export function HookDesigner() {
   const params: HookParams = {
     wireDiameter,
     tolerance,
-    wallThickness,
-    hookHeight,
-    bodyLength,
-    clipDepth,
-    armLength,
-    armThickness,
-    armMountHeight,
     width,
+    wallThickness,
+    clipWallThickness,
+    clipCapHeight,
+    clipOpeningDepth,
+    bodyLength,
+    armLength,
+    armTopOffset,
     stopperEnabled,
     stopperHeight,
     stopperThickness,

--- a/src/lib/hookGeometry.ts
+++ b/src/lib/hookGeometry.ts
@@ -1,221 +1,134 @@
 import * as THREE from "three"
 
+/**
+ * Parametric bracket hook for a 54x54 mm grid-mesh wall.
+ *
+ * Coordinate system (ZY profile, extruded along X):
+ *   Z = depth (positive = out from wall, toward room)
+ *   Y = height (positive = up)
+ *   X = width (extrusion direction)
+ * Origin (0, 0) sits at the gripped wire center.
+ *
+ * Shape silhouette (CCW):
+ *   A ── L ─────── H  (clip cap + back-wall top + stopper top)
+ *   │             │
+ *   B ── C─┐ ┌─E  │
+ *          │o│    │   (slot arc around wire at origin)
+ *          └─┘──K J
+ *              │  (arm top horizontal)
+ *              F───┐
+ *                   \  (diagonal brace bottom)
+ *                    G
+ */
 export interface HookParams {
-  wireDiameter: number
-  tolerance: number
-  wallThickness: number
-  hookHeight: number       // clip cap above the wire
-  bodyLength: number       // how far the back wall hangs below the wire (to lower grid wire)
-  clipDepth: number        // how far below wire centre the J-clip notch extends (mm)
-  armLength: number        // horizontal reach of the shelf
-  armThickness: number     // constant vertical depth of the arm/shelf
-  armMountHeight: number   // shelf height above body bottom; controls bracket steepness
-  width: number
-  stopperEnabled: boolean  // whether to add an upward bump at the arm tip
-  stopperHeight: number    // bump height above shelf top
-  stopperThickness: number // bump depth (Z extent past arm tip)
+  wireDiameter: number      // diameter of grid wire (mm)
+  tolerance: number         // slot radius = wireDiameter/2 + tolerance (mm)
+  width: number             // extrusion width — must span >= 1 grid cell (mm)
+  wallThickness: number     // back-wall Z thickness (mm)
+  clipWallThickness: number // outer U-clip wall Z thickness, behind the wire (mm)
+  clipCapHeight: number     // material above wire center up to top of clip (mm)
+  clipOpeningDepth: number  // how far below wire center the outer U wall extends (mm)
+  bodyLength: number        // back-wall length below wire center (mm)
+  armLength: number         // horizontal reach from back-wall-inner to arm tip (mm)
+  armTopOffset: number      // arm top Y position below wire center, i.e. |-armTopY| (mm)
+  stopperEnabled: boolean   // whether the arm tip has an upward lip
+  stopperHeight: number     // stopper height above arm top (mm)
+  stopperThickness: number  // stopper Z thickness, measured inward from arm-tip outer (mm)
 }
 
 export const DEFAULT_PARAMS: HookParams = {
   wireDiameter: 4,
   tolerance: 0.5,
-  wallThickness: 3,
-  hookHeight: 10,
-  bodyLength: 54,
-  clipDepth: 10,        // J-clip notch extends 10mm below wire centre
-  armLength: 55,
-  armThickness: 8,
-  armMountHeight: 40,   // shelf is 40mm above body bottom (~3/4 of bodyLength)
-  width: 30,
+  width: 25,
+  wallThickness: 6,
+  clipWallThickness: 6,
+  clipCapHeight: 9,
+  clipOpeningDepth: 11,
+  bodyLength: 95,
+  armLength: 100,
+  armTopOffset: 41,
   stopperEnabled: true,
-  stopperHeight: 6,
-  stopperThickness: 3,
-}
-
-/** Approximate an arc from startAngle to endAngle (radians) as lineTo points. */
-function arcPoints(
-  cx: number, cy: number, r: number,
-  startAngle: number, endAngle: number,
-  segments = 24,
-): [number, number][] {
-  const pts: [number, number][] = []
-  for (let i = 0; i <= segments; i++) {
-    const t = startAngle + (endAngle - startAngle) * (i / segments)
-    pts.push([cx + r * Math.cos(t), cy + r * Math.sin(t)])
-  }
-  return pts
+  stopperHeight: 10,
+  stopperThickness: 6,
 }
 
 /**
- * Creates a BufferGeometry for the hook by extruding a 2D profile.
- *
- * Shape overview (side view, ZY plane, wire centre at origin):
- *
- *   J-clip — small bracket at the TOP only; grips the upper grid wire (Y=0)
- *   Back wall — solid plate running the full body height (no inner walls below clip)
- *   Shelf arm — horizontal surface extending forward from the clip-zone front face
- *   Triangle bracket — diagonal from arm tip all the way back to body bottom
- *   Stopper — optional upward bump at the arm tip
- *
- * Retention: J-clip prevents upward lift-off. The diagonal bracket's bottom corner
- * rests against the lower grid wire; gravity + arm load keeps the hook seated.
- *
- * The outer Shape is a solid silhouette (no inner wall edges). The wire slot is
- * cut as a closed THREE.Path hole via shape.holes — this avoids the full-height
- * hollow channel of the previous design.
- *
- * THREE.ExtrudeGeometry extrudes a Shape (in its XY plane) along +Z.
- * We define shape-X = profile-Z (depth) and shape-Y = profile-Y (height),
- * then rotate the geometry -90° around Y so extrusion → world-X (width).
+ * Builds the bracket hook as an X-aligned extrusion of its ZY silhouette.
+ * Slot ceiling is a CW arc over the wire (interior is CCW polygon overall).
  */
 export function buildHookGeometry(params: HookParams): THREE.BufferGeometry {
-  // Guard: fall back to defaults for any undefined field (HMR / stale Leva state)
   const d = DEFAULT_PARAMS
   const p: HookParams = {
-    wireDiameter:    params.wireDiameter    ?? d.wireDiameter,
-    tolerance:       params.tolerance       ?? d.tolerance,
-    wallThickness:   params.wallThickness   ?? d.wallThickness,
-    hookHeight:      params.hookHeight      ?? d.hookHeight,
-    bodyLength:      params.bodyLength      ?? d.bodyLength,
-    clipDepth:       params.clipDepth       ?? d.clipDepth,
-    armLength:       params.armLength       ?? d.armLength,
-    armThickness:    params.armThickness    ?? d.armThickness,
-    armMountHeight:  params.armMountHeight  ?? d.armMountHeight,
-    width:           params.width           ?? d.width,
-    stopperEnabled:  params.stopperEnabled  ?? d.stopperEnabled,
-    stopperHeight:   params.stopperHeight   ?? d.stopperHeight,
-    stopperThickness: params.stopperThickness ?? d.stopperThickness,
+    wireDiameter:      params.wireDiameter      ?? d.wireDiameter,
+    tolerance:         params.tolerance         ?? d.tolerance,
+    width:             params.width             ?? d.width,
+    wallThickness:     params.wallThickness     ?? d.wallThickness,
+    clipWallThickness: params.clipWallThickness ?? d.clipWallThickness,
+    clipCapHeight:     params.clipCapHeight     ?? d.clipCapHeight,
+    clipOpeningDepth:  params.clipOpeningDepth  ?? d.clipOpeningDepth,
+    bodyLength:        params.bodyLength        ?? d.bodyLength,
+    armLength:         params.armLength         ?? d.armLength,
+    armTopOffset:      params.armTopOffset      ?? d.armTopOffset,
+    stopperEnabled:    params.stopperEnabled    ?? d.stopperEnabled,
+    stopperHeight:     params.stopperHeight     ?? d.stopperHeight,
+    stopperThickness:  params.stopperThickness  ?? d.stopperThickness,
   }
 
-  const wg   = p.wireDiameter / 2 + p.tolerance   // half-slot width
-  const zb   = -(wg + p.wallThickness)             // outer back face
-  const zbi  = -wg                                 // inner back face
-  const zfi  = wg                                  // inner front face
-  const zfo  = wg + p.wallThickness                // outer front face
-  const zarm = zfo + p.armLength                   // arm tip Z
+  const wg        = p.wireDiameter / 2 + p.tolerance
+  const zClipOut  = -(wg + p.clipWallThickness)
+  const zSlotOut  = -wg
+  const zBackOut  = wg
+  const zBackIn   = wg + p.wallThickness
+  const zArmTip   = zBackIn + p.armLength
+  const zStopIn   = zArmTip - p.stopperThickness
 
-  const yt   = p.hookHeight                        // clip cap top
-  const ysb  = -p.bodyLength                       // body bottom (lower wire level)
-
-  // Clamp armMountHeight so shelf is always above the arm thickness
-  const mountH = Math.max(p.armMountHeight, p.armThickness + 1)
-  const yShelf = ysb + mountH                      // shelf Y level
-
-  // Arc for the wire slot ceiling: CCW semicircle (wg,0)→(0,wg)→(-wg,0)
-  const arc = arcPoints(0, 0, wg, 0, Math.PI, 24)
-
-  // ── Shape overview ────────────────────────────────────────────────────────────
-  //
-  // The hook has two distinct structural zones that share only the outer back wall:
-  //
-  //   CLIP ZONE  (yShelf → yt, full width zb→zfo):
-  //     The J-clip bracket. Solid block with the slot hole punched through it.
-  //     The lower grid wire passes ALONGSIDE the outer back face (zb) here —
-  //     it does NOT enter the solid. The J-clip hole keeps the wire slot clear.
-  //
-  //   BRACKET ZONE  (ysb → yShelf, front half only zbi→zfo+armLength):
-  //     The arm shelf + diagonal brace. Lives entirely at Z ≥ zbi (-2.5 mm),
-  //     which keeps it clear of the lower grid wire at Z=0 down at Y=ysb.
-  //     The outer back wall does NOT extend into this zone — there is no
-  //     back-wall material at negative Z below the arm mount level.
-  //
-  // Because the back wall (negative Z) stops at yShelf, and the bracket zone
-  // is entirely at positive-ish Z, the lower wire at (Z=0, Y=ysb) sits just
-  // outside the solid on its back-left face rather than going through it.
-  //
-  // Profile trace (CCW):
-  //   back-wall bottom (zb, yShelf) → up back wall → top cap → down outer front
-  //   → shelf → arm tip → diagonal to (zbi, ysb) → body bottom → closePath
+  const yCapTop   = p.clipCapHeight
+  const yClipBot  = -(wg + p.clipOpeningDepth)
+  const yArmTop   = -p.armTopOffset
+  const yStopTop  = yArmTop + p.stopperHeight
+  const yBodyBot  = -p.bodyLength
 
   const shape = new THREE.Shape()
 
-  // ── Clip zone: back wall + top cap + outer front ──────────────────────────────
-  shape.moveTo(zb,  yShelf)       // back-wall bottom corner (arm mount level)
-  shape.lineTo(zb,  yt)           // up full outer back wall
-  shape.lineTo(zfo, yt)           // top cap
-  shape.lineTo(zfo, yShelf)       // outer front face down to shelf level
+  // Clip cap + outer-U wall
+  shape.moveTo(zClipOut, yCapTop)          // A: top-left of clip cap
+  shape.lineTo(zClipOut, yClipBot)         // B: outer-U wall, bottom
+  shape.lineTo(zSlotOut, yClipBot)         // C: underside of clip, inner edge
+  shape.lineTo(zSlotOut, 0)                // D: slot-left at wire-center height
 
-  // ── Bracket zone: shelf + arm tip + diagonal brace ───────────────────────────
-  shape.lineTo(zarm, yShelf)      // shelf top (horizontal)
+  // Slot ceiling — CW half-arc OVER the wire (interior material above arc)
+  shape.absarc(0, 0, wg, Math.PI, 0, true) // D → E via top
 
+  // Back-wall outer face down to body bottom
+  shape.lineTo(zBackOut, yBodyBot)         // F
+
+  // Diagonal underside of brace up to arm tip
+  shape.lineTo(zArmTip, yArmTop)           // G
+
+  // Arm tip: optional stopper
   if (p.stopperEnabled) {
-    shape.lineTo(zarm,                      yShelf + p.stopperHeight)
-    shape.lineTo(zarm + p.stopperThickness, yShelf + p.stopperHeight)
-    shape.lineTo(zarm + p.stopperThickness, yShelf - p.armThickness)
-  } else {
-    shape.lineTo(zarm, yShelf - p.armThickness)
+    shape.lineTo(zArmTip, yStopTop)        // H
+    shape.lineTo(zStopIn, yStopTop)        // I
+    shape.lineTo(zStopIn, yArmTop)         // J
   }
 
-  // Diagonal brace: arm tip → inner back face at body bottom.
-  // Ends at zbi (= -wg = -2.5 mm), not zb, so the outer-back zone at
-  // negative Z stays clear of the lower wire at Z=0.
-  shape.lineTo(zbi, ysb)
+  // Arm top horizontal back to back-wall inner
+  shape.lineTo(zBackIn, yArmTop)           // K
 
-  // Body bottom: 3 mm step from inner back (zbi) to outer back (zb) — the thin
-  // strip of material at the very base of the back wall.
-  shape.lineTo(zb, ysb)
+  // Back-wall inner face up to clip cap top
+  shape.lineTo(zBackIn, yCapTop)           // L
 
-  // Left face: back wall going up from body bottom to back-wall bottom corner.
-  // closePath() draws this segment automatically.
-  shape.closePath()               // (zb, ysb) → (zb, yShelf) — completes back wall
-
-  // ── J-clip slot hole ─────────────────────────────────────────────────────────
-  // Closed void punched into the clip zone. Floor is clamped to stay above yShelf
-  // so the hole never reaches into the open bracket zone below.
-  const ySlotBot = Math.max(-p.clipDepth, yShelf + 1)
-
-  const slotPath = new THREE.Path()
-  slotPath.moveTo(zfi, ySlotBot)
-  slotPath.lineTo(zfi, 0)
-  for (const [x, y] of arc) slotPath.lineTo(x, y)
-  slotPath.lineTo(zbi, ySlotBot)
-  slotPath.closePath()
-
-  shape.holes = [slotPath]
+  shape.closePath()                        // L → A along horizontal top
 
   const geometry = new THREE.ExtrudeGeometry(shape, {
     depth: p.width,
     bevelEnabled: false,
+    curveSegments: 24,
   })
 
-  // Centre in X (extrusion runs 0→width along shape's Z axis)
+  // Centre along the extrusion axis, then rotate so extrusion = world X
   geometry.translate(0, 0, -p.width / 2)
-
-  // Rotate so extrusion aligns with world X: -π/2 around Y
   geometry.applyMatrix4(new THREE.Matrix4().makeRotationY(-Math.PI / 2))
 
   return geometry
-}
-
-/**
- * Returns representative 2D profile vertices for preview/display.
- * Returns the outer silhouette only — matches the outer Shape in buildHookGeometry.
- * The J-clip slot (hole) is omitted; the profile shows the solid boundary.
- */
-export function buildHookProfile(p: HookParams): [number, number][] {
-  const wg   = p.wireDiameter / 2 + p.tolerance
-  const zb   = -(wg + p.wallThickness)
-  const zbi  = -wg
-  const zfo  = wg + p.wallThickness
-  const zarm = zfo + p.armLength
-  const yt   = p.hookHeight
-  const ysb  = -p.bodyLength
-  const mountH = Math.max(p.armMountHeight, p.armThickness + 1)
-  const yShelf = ysb + mountH
-
-  return [
-    [zb,   yShelf],  // back-wall bottom corner (arm mount level)
-    [zb,   yt],
-    [zfo,  yt],
-    [zfo,  yShelf],
-    [zarm, yShelf],
-    ...(p.stopperEnabled ? [
-      [zarm,                      yShelf + p.stopperHeight],
-      [zarm + p.stopperThickness, yShelf + p.stopperHeight],
-      [zarm + p.stopperThickness, yShelf - p.armThickness],
-    ] as [number, number][] : [[zarm, yShelf - p.armThickness]] as [number, number][]),
-    [zbi,  ysb],  // diagonal to inner back at body bottom
-    [zb,   ysb],  // body bottom (outer back)
-    // closePath → (zb, yShelf) — closes the back wall
-  ]
 }


### PR DESCRIPTION
## Summary
- Replaces the hook geometry with a minimal parametric wedge bracket derived from `05-Krok-til-boden.3mf` (the Shapr3D reference)
- 13 params, single ZY-profile extrusion — no CSG, no boolean ops
- Leva panel reorganized into folders matching the physical parts: **Gitterwire**, **J-klype**, **Kropp**, **Arm**, **Stopper**, **Visning**
- Bonus commits already on the branch: semantic grid visualization (3D cylinder wires) and the reference `.3mf` checked in

## Silhouette
ZY-plane profile extruded along X (wire center at origin):

- J-clip (outer wall + cap + downward opening) wraps the horizontal grid wire
- `absarc(0, 0, wg, Math.PI, 0, true)` carves the slot ceiling over the wire while keeping the outer polygon CCW
- Solid back wall down to `bodyLength`
- Diagonal brace from back-wall-bottom up to arm tip → tapered wedge underside
- Horizontal arm top + optional stopper at the tip

## Files
- `src/lib/hookGeometry.ts` — rewritten from scratch (~208 → ~120 lines)
- `src/components/HookDesigner.tsx` — Leva controls reorganized to match new params

## Test plan
- [x] Dev server renders without errors
- [x] Hook mounts on grid with J-clip engaging the top horizontal wire
- [x] Silhouette matches the reference Shapr3D model (vertical back wall, diagonal brace, arm + stopper)
- [x] GridPreview still works with the generic params (`bodyLength`, `width`, `wireDiameter`, `gridOuter`)
- [ ] Export `.stl` and `.3mf`, open in Bambu Studio, confirm geometry is watertight

🤖 Generated with [Claude Code](https://claude.com/claude-code)