### PR TITLE
Calibrate default params and widen slider ranges

### DIFF
--- a/src/components/HookDesigner.tsx
+++ b/src/components/HookDesigner.tsx
@@ -193,12 +193,12 @@ export function HookDesigner() {
       gridOuter: { value: 54, min: 40, max: 80, step: 0.5, label: "Rutestørrelse (mm)" },
     }),
     "J-klype": folder({
-      clipWallThickness: { value: DEFAULT_PARAMS.clipWallThickness, min: 2, max: 12, step: 0.5, label: "Yttervegg (mm)" },
+      clipWallThickness: { value: DEFAULT_PARAMS.clipWallThickness, min: 2, max: 20, step: 0.5, label: "Yttervegg (mm)" },
       clipCapHeight: { value: DEFAULT_PARAMS.clipCapHeight, min: 4, max: 20, step: 0.5, label: "Topphøyde (mm)" },
       clipOpeningDepth: { value: DEFAULT_PARAMS.clipOpeningDepth, min: 5, max: 25, step: 0.5, label: "Åpning nedover (mm)" },
     }),
     "Kropp": folder({
-      wallThickness: { value: DEFAULT_PARAMS.wallThickness, min: 2, max: 12, step: 0.5, label: "Bakvegg (mm)" },
+      wallThickness: { value: DEFAULT_PARAMS.wallThickness, min: 2, max: 20, step: 0.5, label: "Bakvegg (mm)" },
       bodyLength: { value: DEFAULT_PARAMS.bodyLength, min: 40, max: 150, step: 1, label: "Høyde (mm)" },
       width: { value: DEFAULT_PARAMS.width, min: 10, max: 80, step: 1, label: "Bredde (mm)" },
     }),

--- a/src/lib/hookGeometry.ts
+++ b/src/lib/hookGeometry.ts
@@ -40,16 +40,16 @@ export const DEFAULT_PARAMS: HookParams = {
   wireDiameter: 4,
   tolerance: 0.5,
   width: 25,
-  wallThickness: 6,
-  clipWallThickness: 6,
-  clipCapHeight: 9,
-  clipOpeningDepth: 11,
-  bodyLength: 95,
+  wallThickness: 10,
+  clipWallThickness: 10,
+  clipCapHeight: 10,
+  clipOpeningDepth: 13.5,
+  bodyLength: 120,
   armLength: 100,
-  armTopOffset: 41,
+  armTopOffset: 50,
   stopperEnabled: true,
   stopperHeight: 10,
-  stopperThickness: 6,
+  stopperThickness: 10,
 }
 
 /**


### PR DESCRIPTION
The defaults now reflect the recommended hook rather than the original placeholder values. Wall thicknesses (both back-wall and clip outer wall) go from 6mm to 10mm, the body is taller (120mm vs 95mm), the stopper is thicker (10mm vs 6mm), and the arm offset is deeper (50mm vs 41mm). Slider max for `wallThickness` and `clipWallThickness` is widened from 12mm to 20mm so heavier hook designs aren't artificially capped.

Closes strombraaten/3D-Print-Generator#12

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Sonnet_4.6_(200K)-D97757?logo=claude&logoColor=white)