### PR TITLE
Add README and update header copy to plain Norwegian

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# 3D print-generator
+
+Lag skreddersydde kroker til gitterveggen din, rett fra nettleseren. Tilpass størrelsen og eksporter til 3D-printer.
+
+**[→ Åpne verktøyet på 3d.simenlager.no](https://3d.simenlager.no)**
+
+---
+
+## Hva er det?
+
+Et nettbasert verktøy hvor du kan lage skreddersydde kroker til gittervegger, og eksportere dem direkte til en 3D-printer. Krever minimalt med ferdigheter – bare juster, forhåndsvis og eksporter.
+
+Kroker passer til gittervegger som man typisk bruker for å separere boder fra hverandre i sameier.
+
+## Hvorfor?
+
+Boden blir så mye mer brukbar når du får hengt ting på veggen i stedet for at det hoper seg opp på gulvet. Kanskje du vil henge opp skiene dine? En sekk med ved? Noen klappstoler? Got you covered.
+
+## Sånn her funker det
+
+1. Gå til [3d.simenlager.no](https://3d.simenlager.no)
+2. Juster parametrene i panelet (som f. lengde på armen, bredde på kroken, høyden osv.)
+3. Se resultatet live i 3D-visningen
+4. Klikk **Export .3mf** og åpne filen i Bambu Studio
+5. Print i vei
+
+## Utgangspunktet
+
+Som et utgangspunkt er krokene lagd for gitterveggen som jeg selv har i boden (spesifikke mål under), men du kan faktisk tilpasse alt dette i verktøyet.
+
+| Parameter | Verdi |
+|-----------|-------|
+| Ytre rasteravstand | 54 × 54 mm |
+| Tråddiameter | 4 mm |
+| Indre åpning | ~45 × 46 mm |
+| Anbefalt toleranse | 0,5 mm (testet med PLA) |

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,7 @@ import { HookDesigner } from "@/components/HookDesigner"
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
-    <meta name="description" content="Parametrisk 3D-designer for gitternett-kroker" />
+    <meta name="description" content="Lag skreddersydde kroker til gitterveggen din. Tilpass størrelsen og eksporter til 3D-printer." />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>3D Print Generator</title>
     <script is:inline>
@@ -29,7 +29,7 @@ import { HookDesigner } from "@/components/HookDesigner"
         <div class="flex items-center gap-3">
           <span class="text-sm font-semibold tracking-tight">3D Print Generator</span>
           <span class="hidden text-xs text-muted-foreground sm:inline">
-            Parametrisk krokedesigner for gridbod
+            Lag skreddersydde kroker til gitterveggen din. Tilpass størrelsen og eksporter til 3D-printer.
           </span>
         </div>
         <ModeToggle client:load />


### PR DESCRIPTION
## Summary

- Adds `README.md` with a practical, non-technical focus: what the tool does, motivation, usage steps, and grid-mesh specs — using "gittervegg" consistently as the term for grid-mesh walls
- Updates the header subtitle from "Parametrisk krokedesigner for gridbod" to plain-language Norwegian copy
- Updates `<meta name="description">` to match

Closes #10
Closes #15

## Test plan

- [ ] Subtitle is readable and fits on one line at sm+ viewports
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.ai/claude-code)